### PR TITLE
refactor(lint): Make sure the linting CI runs on every PR instead of

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,7 +3,6 @@ name: Lint
 on:
   pull_request:
     types: [opened, synchronize, reopened]
-    branches: [main]
 
 permissions:
   contents: read


### PR DESCRIPTION
## Description

Describe the purpose of this pull request and the changes made.
Made linting CI run on all PR instead of only on PRs to main

## Related Issue(s) and PR(s)

List any related issues or pull requests. Example: Fixes #123, Closes #456.
NIL

## Changes Made

- Made linting run on all PRs

## Additional Notes

Provide any extra information, such as testing steps, potential impact or deployment considerations.
NIL