### PR TITLE
Delete flag

### DIFF
--- a/internal/fileIO/utils.go
+++ b/internal/fileIO/utils.go
@@ -27,3 +27,18 @@ func (f *FileIO) EnsureVaultDir() error {
 func (f *FileIO) PurgeVault() error {
 	return os.RemoveAll(f.VaultDir)
 }
+
+// function to check if vault exists
+func (f *FileIO) IsEmpty() (bool, error) {
+	_, err := os.Stat(f.VaultPath)
+	if err == nil {
+		// file exists
+		return false, nil
+	}
+	if os.IsNotExist(err) {
+		// file does not exist
+		return true, nil
+	}
+	// other errors (e.g., permission)
+	return false, err
+}

--- a/internal/fileIO/write.go
+++ b/internal/fileIO/write.go
@@ -14,7 +14,6 @@ func (f *FileIO) WriteMeta(meta model.Meta) error {
 	if err != nil {
 		return fmt.Errorf("failed to marshal meta: %w", err)
 	}
-	fmt.Println(string(data))
 	return os.WriteFile(f.MetaPath, data, 0600)
 }
 

--- a/internal/vault/behavior.go
+++ b/internal/vault/behavior.go
@@ -2,6 +2,7 @@
 package vault
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/Cyrof/govault/internal/model"
@@ -28,4 +29,13 @@ func (v *Vault) DisplayKeys() {
 	for key := range v.Secrets {
 		fmt.Println(" -", key)
 	}
+}
+
+// function to delete
+func (v *Vault) DeleteSecret(key string) error {
+	if !v.CheckKey(key) {
+		return errors.New("key not found in vault")
+	}
+	delete(v.Secrets, key)
+	return nil
 }

--- a/internal/vault/utils.go
+++ b/internal/vault/utils.go
@@ -1,0 +1,9 @@
+package vault
+
+// function to check if key exist
+func (v *Vault) CheckKey(key string) bool {
+	if _, exist := v.Secrets[key]; exist {
+		return true
+	}
+	return false
+}

--- a/pkg/cli/cli.go
+++ b/pkg/cli/cli.go
@@ -28,6 +28,18 @@ func handleExistingUser(v *vault.Vault) {
 		logger.Logger.Fatalw("Failed to login", "error", err)
 	}
 
+	empty, err := v.FileIO.IsEmpty()
+	if err != nil {
+		Error("Unexpected error while checking fault file.\n\n")
+		logger.Logger.Fatalw("Error checking vault file", "error", err)
+	}
+
+	if empty {
+		logger.Logger.Infow("Vault file not found", "path", v.FileIO.VaultPath)
+		Success("Login successful.\nVault is empty.\n\n")
+		return
+	}
+
 	if err := v.Load(); err != nil {
 		Error("Error loading vault.\n\n")
 		logger.Logger.Panicw("Error loading vault", "error", err)

--- a/pkg/cli/promptDel.go
+++ b/pkg/cli/promptDel.go
@@ -1,0 +1,30 @@
+package cli
+
+import (
+	"bufio"
+	"os"
+	"strings"
+)
+
+func PromptDel() bool {
+	reader := bufio.NewReader(os.Stdin)
+
+	for {
+		Error("Are you sure you want to delete this secret?\n")
+		Warn("This action is irreversible and the secret cannot be recoved. (yes/no): ")
+		confirm, _ := reader.ReadString('\n')
+
+		confirm = strings.TrimSpace(confirm)
+
+		if confirm == "" {
+			Warn("Cannot be empty.\nPlease try again.\n\n")
+			continue
+		}
+
+		if confirm == "yes" {
+			return true
+		} else {
+			return false
+		}
+	}
+}

--- a/pkg/cobraCLI/delete.go
+++ b/pkg/cobraCLI/delete.go
@@ -35,6 +35,11 @@ var deleteCmd = &cobra.Command{
 			return
 		}
 
+		if err := v.Save(); err != nil {
+			cli.Error("Error saving vault: %v\n", err)
+			logger.Logger.Errorw("Error saving vault", "error", err)
+		}
+
 		cli.Success("Secret '%s' deleted successfully.\n", key)
 		logger.Logger.Infow("Secret deleted", "key", key)
 	},

--- a/pkg/cobraCLI/delete.go
+++ b/pkg/cobraCLI/delete.go
@@ -1,0 +1,51 @@
+package cobraCLI
+
+import (
+	"fmt"
+
+	"github.com/Cyrof/govault/internal/logger"
+	"github.com/Cyrof/govault/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+var deleteCmd = &cobra.Command{
+	Use:     "delete",
+	Aliases: []string{"d"},
+	Short:   "Delete a secret from the vault",
+	Long:    "Removes a stored secret from the vault using its key. This action is irreversible and the deleted secret cannot be recovered.",
+	Example: `
+	govault delete --key github
+	govault d -k email
+	`,
+	Run: func(cmd *cobra.Command, args []string) {
+		if !v.CheckKey(key) {
+			cli.Error("Key '%s' not found in the vault.", key)
+			logger.Logger.Warnw("Key not found", "key", key)
+			return
+		}
+
+		if !cli.PromptDel() {
+			fmt.Println("Deletion aborted by user.")
+			return
+		}
+
+		if err := v.DeleteSecret(key); err != nil {
+			cli.Error("Failed to delete secret: %v\n", err)
+			logger.Logger.Errorw("Failed to delete secret", "key", key, "error", err)
+			return
+		}
+
+		cli.Success("Secret '%s' deleted successfully.\n", key)
+		logger.Logger.Infow("Secret deleted", "key", key)
+	},
+}
+
+func init() {
+	deleteCmd.Flags().StringVarP(&key, "key", "k", "", "The name/identifier of the service$")
+	if err := deleteCmd.MarkFlagRequired("key"); err != nil {
+		cli.Error("Failed to mark required flag: %v\n", err)
+		logger.Logger.Panicw("Failed to mark flag as required", "flag", "key", "error", err)
+	}
+
+	rootCmd.AddCommand(deleteCmd)
+}


### PR DESCRIPTION
## Description

Describe the purpose of this pull request and the changes made.
Created a new `delete` feature to allow users to delete stored services. Also fixed an issue with the login logic where it previously just assumes that on the first run, the user will add something to the vault meaning the vault file is created. But infact if the user do not add anything on the initial run, the vault file is not created and subsequent runs will produce an issue loading the file since it does not exist. 

## Related Issue(s) and PR(s)

List any related issues or pull requests. Example: Fixes #123, Closes #456.
- closes #46 

## Changes Made

- Created a `delete` feature to allow user to delete a key
- Fixed flawed loading of vault file logic

## Additional Notes

Provide any extra information, such as testing steps, potential impact or deployment considerations.
NIL