### PR TITLE
Feature/edit

### DIFF
--- a/internal/vault/behavior.go
+++ b/internal/vault/behavior.go
@@ -39,3 +39,15 @@ func (v *Vault) DeleteSecret(key string) error {
 	delete(v.Secrets, key)
 	return nil
 }
+
+// function to updated password
+func (v *Vault) EditPassword(key string, newPass string) error {
+	if !v.CheckKey(key) {
+		return errors.New("key not found in vault")
+	}
+	v.Secrets[key] = model.Secret{
+		Key:   key,
+		Value: newPass,
+	}
+	return nil
+}

--- a/pkg/cli/promptDel.go
+++ b/pkg/cli/promptDel.go
@@ -1,18 +1,14 @@
 package cli
 
 import (
-	"bufio"
-	"os"
 	"strings"
 )
 
 func PromptDel() bool {
-	reader := bufio.NewReader(os.Stdin)
-
 	for {
 		Error("Are you sure you want to delete this secret?\n")
 		Warn("This action is irreversible and the secret cannot be recoved. (yes/no): ")
-		confirm, _ := reader.ReadString('\n')
+		confirm, _ := Reader.ReadString('\n')
 
 		confirm = strings.TrimSpace(confirm)
 

--- a/pkg/cli/promptEdit.go
+++ b/pkg/cli/promptEdit.go
@@ -21,7 +21,7 @@ func PromptEdit(key string) (string, error) {
 		if confirm == "yes" {
 			return promptPassword(key), nil
 		} else {
-			return "", errors.New("Edit cancelled by user.")
+			return "", errors.New("Edit cancelled by user")
 		}
 	}
 }

--- a/pkg/cli/promptEdit.go
+++ b/pkg/cli/promptEdit.go
@@ -1,0 +1,41 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func PromptEdit(key string) (string, error) {
+	for {
+		Warn("Do you want to edit this secret? (yes/no): ")
+		confirm, _ := Reader.ReadString('\n')
+
+		confirm = strings.TrimSpace(confirm)
+
+		if confirm == "" {
+			Warn("Cannot be empty.\nPlease try again.\n\n")
+			continue
+		}
+
+		if confirm == "yes" {
+			return promptPassword(key), nil
+		} else {
+			return "", errors.New("Edit cancelled by user.")
+		}
+	}
+}
+
+func promptPassword(key string) string {
+	for {
+		fmt.Printf("Enter the new password for %s: ", key)
+		pass, _ := Reader.ReadString('\n')
+
+		if pass == "" {
+			Warn("Cannot be empty.\nPlease try again.\n\n")
+			continue
+		}
+
+		return pass
+	}
+}

--- a/pkg/cli/promptEdit.go
+++ b/pkg/cli/promptEdit.go
@@ -21,7 +21,7 @@ func PromptEdit(key string) (string, error) {
 		if confirm == "yes" {
 			return promptPassword(key), nil
 		} else {
-			return "", errors.New("Edit cancelled by user")
+			return "", errors.New("edit cancelled by user")
 		}
 	}
 }

--- a/pkg/cli/promptPw.go
+++ b/pkg/cli/promptPw.go
@@ -1,22 +1,18 @@
 package cli
 
 import (
-	"bufio"
 	"fmt"
-	"os"
 	"strings"
 )
 
 // prompt for new password creation
 func PromptNewPassword() (string, error) {
-	reader := bufio.NewReader(os.Stdin)
-
 	for {
 		fmt.Print("Enter a new master password: ")
-		pass1, _ := reader.ReadString('\n')
+		pass1, _ := Reader.ReadString('\n')
 
 		fmt.Print("Confirm your master password: ")
-		pass2, _ := reader.ReadString('\n')
+		pass2, _ := Reader.ReadString('\n')
 
 		// format inputs
 		pass1 = strings.TrimSpace(pass1)
@@ -38,11 +34,9 @@ func PromptNewPassword() (string, error) {
 }
 
 func PromptPassword() (string, error) {
-	reader := bufio.NewReader(os.Stdin)
-
 	for {
 		fmt.Print("Enter your master password: ")
-		pass1, _ := reader.ReadString('\n')
+		pass1, _ := Reader.ReadString('\n')
 		pass1 = strings.TrimSpace(pass1)
 
 		if pass1 == "" {

--- a/pkg/cli/purge.go
+++ b/pkg/cli/purge.go
@@ -1,19 +1,15 @@
 package cli
 
 import (
-	"bufio"
-	"os"
 	"strings"
 )
 
 func PromptPurge() bool {
-	reader := bufio.NewReader(os.Stdin)
-
 	for {
 		Error("WARNING: This action will permanently delete all stored secrets and reset the vault.\n")
 		Error("This operation cannot be undone.\n\n")
 		Warn("Are you sure you want to continue? (yes/no): ")
-		confirm, _ := reader.ReadString('\n')
+		confirm, _ := Reader.ReadString('\n')
 
 		// format input
 		confirm = strings.TrimSpace(confirm)

--- a/pkg/cli/vars.go
+++ b/pkg/cli/vars.go
@@ -1,0 +1,8 @@
+package cli
+
+import (
+	"bufio"
+	"os"
+)
+
+var Reader = bufio.NewReader(os.Stdin)

--- a/pkg/cobraCLI/delete.go
+++ b/pkg/cobraCLI/delete.go
@@ -46,7 +46,7 @@ var deleteCmd = &cobra.Command{
 }
 
 func init() {
-	deleteCmd.Flags().StringVarP(&key, "key", "k", "", "The name/identifier of the service$")
+	deleteCmd.Flags().StringVarP(&key, "key", "k", "", "The name/identifier of the service")
 	if err := deleteCmd.MarkFlagRequired("key"); err != nil {
 		cli.Error("Failed to mark required flag: %v\n", err)
 		logger.Logger.Panicw("Failed to mark flag as required", "flag", "key", "error", err)

--- a/pkg/cobraCLI/edit.go
+++ b/pkg/cobraCLI/edit.go
@@ -1,0 +1,60 @@
+package cobraCLI
+
+import (
+	"fmt"
+
+	"github.com/Cyrof/govault/internal/logger"
+	"github.com/Cyrof/govault/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+var editCmd = &cobra.Command{
+	Use:     "edit",
+	Aliases: []string{"e"},
+	Short:   "Edit a stored secret in the vault",
+	Long:    "Edit a existing secret in the vault by specifying its key and updating its value securely.",
+	Example: `
+	govault edit --key github
+	govault e -k email
+	`,
+	Run: func(cmd *cobra.Command, args []string) {
+		// check if key exist
+		if !v.CheckKey(key) {
+			cli.Error("Key '%s' not found in the vault.", key)
+			logger.Logger.Warnw("Key not found", "key", key)
+			return
+		}
+
+		// prompt user for confirmation
+		newPass, err := cli.PromptEdit(key)
+		if err != nil {
+			fmt.Println(err)
+		}
+
+		// change existing password logic
+		if err := v.EditPassword(key, newPass); err != nil {
+			cli.Error("Failed to update password: %v\n", err)
+			logger.Logger.Errorw("Failed to update password", "key", key, "error", err)
+			return
+		}
+
+		// save changes
+		if err := v.Save(); err != nil {
+			cli.Error("Error saving vault: %v\n", err)
+			logger.Logger.Errorw("Error saving vault", "error", err)
+		}
+
+		cli.Success("'%s' password successfully updated.\n", key)
+		logger.Logger.Infow("Secret updated", "key", key)
+	},
+}
+
+func init() {
+	editCmd.Flags().StringVarP(&key, "key", "k", "", "The name/identifier of the service")
+	if err := editCmd.MarkFlagRequired("key"); err != nil {
+		cli.Error("Failed to mark required flag: %v\n", err)
+		logger.Logger.Panicw("Failed to mark flag as required", "flag", "key", "error", err)
+	}
+
+	rootCmd.AddCommand(editCmd)
+}


### PR DESCRIPTION
## Description

Describe the purpose of this pull request and the changes made.
This feature is to allow user to edit the password for an existing secret saved in the vault instead of recreating it.

## Related Issue(s) and PR(s)

List any related issues or pull requests. Example: Fixes #123, Closes #456.
Closes #47 

## Changes Made

- Added constant variable for Stdin reader 
- Fixed some spelling mistakes 
- Added a edit feature 

## Additional Notes

Provide any extra information, such as testing steps, potential impact or deployment considerations.
NIL