### PR TITLE
Feature/pass gen

### DIFF
--- a/internal/generator/charset.go
+++ b/internal/generator/charset.go
@@ -1,0 +1,31 @@
+package generator
+
+import (
+	"strings"
+)
+
+const (
+	lowercase = "abcdefghijklmnopqrstuvwxyz"
+	uppercase = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	numbers   = "0123456789"
+	symbols   = "!@#$%^&*()-_=+[]{}|;:,.<>?/"
+)
+
+func BuildCharset(opts Options) string {
+	var builder strings.Builder
+
+	if opts.UseLowercase {
+		builder.WriteString(lowercase)
+	}
+	if opts.UseUppercase {
+		builder.WriteString(uppercase)
+	}
+	if opts.UseNumbers {
+		builder.WriteString(numbers)
+	}
+	if opts.UseSymbols {
+		builder.WriteString(symbols)
+	}
+
+	return builder.String()
+}

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -1,0 +1,24 @@
+package generator
+
+import (
+	"crypto/rand"
+	"errors"
+	"math/big"
+)
+
+func GeneratePassword(opts Options) (string, error) {
+	charsetStr := BuildCharset(opts)
+	if charsetStr == "" {
+		return "", errors.New("no charset sets selected")
+	}
+	password := make([]byte, opts.Length)
+	for i := range password {
+		n, err := rand.Int(rand.Reader, big.NewInt(int64(len(charsetStr))))
+		if err != nil {
+			return "", err
+		}
+		password[i] = charsetStr[n.Int64()]
+	}
+
+	return string(password), nil
+}

--- a/internal/generator/options.go
+++ b/internal/generator/options.go
@@ -1,0 +1,17 @@
+package generator
+
+type Options struct {
+	Length       int
+	UseLowercase bool
+	UseUppercase bool
+	UseNumbers   bool
+	UseSymbols   bool
+}
+
+var DefaultOptions = Options{
+	Length:       16,
+	UseLowercase: true,
+	UseUppercase: true,
+	UseNumbers:   true,
+	UseSymbols:   false,
+}

--- a/pkg/cobraCLI/add.go
+++ b/pkg/cobraCLI/add.go
@@ -1,24 +1,56 @@
 package cobraCLI
 
 import (
+	"github.com/Cyrof/govault/internal/generator"
 	"github.com/Cyrof/govault/internal/logger"
 	"github.com/Cyrof/govault/pkg/cli"
 	"github.com/spf13/cobra"
 )
 
+var gen bool
+
 var addCmd = &cobra.Command{
 	Use:     "add",
 	Aliases: []string{"a"},
-	Short:   "Add a new secret",
-	Long:    `The 'add' command allows you to securely store a key-value pair in your local encrypted vault.`,
+	Short:   "Add a new secret or generate one using default settings",
+	Long: `The 'add' command allows you to securely store a key-value pair in your local encrypted vault.
+	You must specify either a manual value using --value, or use --gen to generate a random password.
+	`,
 	Example: `	
 	govault add --key github --value myGitHubToken123
 	govault a -k email -v mypassword
+	govault add --key github --gen
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
-		v.AddSecret(key, value)
-		cli.Success("Secret added.")
-		logger.Logger.Infow("Secret added", "key", key)
+		if value != "" && gen {
+			cli.Error("You cannot use both --value and --gen. Please choose one.")
+			return
+		}
+
+		var secretValue string
+
+		if gen {
+			opts := generator.DefaultOptions
+			pass, err := generator.GeneratePassword(opts)
+			if err != nil {
+				cli.Error("Failed to generate password: %v\n", err)
+				logger.Logger.Errorw("Password generation failed", "error", err)
+				return
+			}
+			secretValue = pass
+			cli.Success("Generated password: %s\n", pass)
+			logger.Logger.Infow("Password generated and added", "key", key)
+		} else if value != "" {
+			secretValue = value
+			logger.Logger.Infow("Secret added manually", "key", key)
+		} else {
+			cli.Error("You must provide either --value or --gen.\n")
+			return
+		}
+
+		v.AddSecret(key, secretValue)
+		cli.Success("Secret added.\n")
+
 		if err := v.Save(); err != nil {
 			cli.Error("Error saving vault: %v\n", err)
 			logger.Logger.Errorw("Error saving vault", "error", err)
@@ -29,11 +61,8 @@ var addCmd = &cobra.Command{
 func init() {
 	addCmd.Flags().StringVarP(&key, "key", "k", "", "The name/identifier for the service")
 	addCmd.Flags().StringVarP(&value, "value", "v", "", "The value to store")
+	addCmd.Flags().BoolVar(&gen, "gen", false, "Generate a random password using default settings")
 	if err := addCmd.MarkFlagRequired("key"); err != nil {
-		cli.Error("Failed to mark flag as required\n\n")
-		logger.Logger.Panicw("Failed to mark flag as required", "flag", "key", "error", err)
-	}
-	if err := addCmd.MarkFlagRequired("value"); err != nil {
 		cli.Error("Failed to mark flag as required\n\n")
 		logger.Logger.Panicw("Failed to mark flag as required", "flag", "key", "error", err)
 	}

--- a/pkg/cobraCLI/generatePassword.go
+++ b/pkg/cobraCLI/generatePassword.go
@@ -1,0 +1,57 @@
+package cobraCLI
+
+import (
+	"github.com/Cyrof/govault/internal/generator"
+	"github.com/Cyrof/govault/internal/logger"
+	"github.com/Cyrof/govault/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+var (
+	length      int
+	noLowercase bool
+	noUppercase bool
+	noNumbers   bool
+	withSymbols bool
+)
+
+var generateCmd = &cobra.Command{
+	Use:     "generate",
+	Aliases: []string{"gen"},
+	Short:   "Generate a secure random password",
+	Long:    "Generate a secure, random password with configurable length and character sets.",
+	Example: `
+	govault generate 
+	govault generate --length 24 --symbols
+	govault generate -l 24 -s
+	govault generate --no-lowercase --no-uppercase
+	`,
+	Run: func(cmd *cobra.Command, args []string) {
+		opts := generator.DefaultOptions
+
+		opts.Length = length
+		opts.UseLowercase = !noLowercase
+		opts.UseUppercase = !noUppercase
+		opts.UseNumbers = !noNumbers
+		opts.UseSymbols = withSymbols
+
+		password, err := generator.GeneratePassword(opts)
+		if err != nil {
+			cli.Error("Error generating password: %v\n", err)
+			logger.Logger.Errorw("Error generating password", "error", err)
+		}
+
+		cli.Success("Generated password: %v", password)
+		logger.Logger.Infow("Password generated successfully")
+	},
+}
+
+func init() {
+	generateCmd.Flags().IntVarP(&length, "length", "l", generator.DefaultOptions.Length, "Length of the password")
+	generateCmd.Flags().BoolVar(&noLowercase, "no-lowercase", !generator.DefaultOptions.UseLowercase, "Exclude lowercase letters")
+	generateCmd.Flags().BoolVar(&noUppercase, "no-uppercase", !generator.DefaultOptions.UseUppercase, "Exclude uppercase letters")
+	generateCmd.Flags().BoolVar(&noNumbers, "no-numbers", !generator.DefaultOptions.UseNumbers, "Exclude numeric characters")
+	generateCmd.Flags().BoolVarP(&withSymbols, "symbols", "s", generator.DefaultOptions.UseSymbols, "Include symbols")
+
+	rootCmd.AddCommand(generateCmd)
+}

--- a/pkg/cobraCLI/root.go
+++ b/pkg/cobraCLI/root.go
@@ -15,6 +15,7 @@ var (
 		"help":       true,
 		"purge":      true,
 		"completion": true,
+		"generate":   true,
 	}
 
 	v *vault.Vault


### PR DESCRIPTION
## Description

Describe the purpose of this pull request and the changes made.
Created a password generator and added it to the cli tool with a new flag called `generate`. Using this flag will create a random password using lowercase, uppercase, and numbers. By default the lenght is `16` and no symbols will be used. There are subflags available for this command as well to allow users the option to not use lowercase etc. This feature is also refactored into the `add` command to allow users to use the generate password flag to generate a password for the service they want to save. 

## Related Issue(s) and PR(s)

List any related issues or pull requests. Example: Fixes #123, Closes #456.
- Closes #34 

## Changes Made

- Created a password generator 
- Added the password generator to the cli using the `generate` flag 
- Added the password generator feature to the `add` command as a subflag `gen`

## Additional Notes

Provide any extra information, such as testing steps, potential impact or deployment considerations.
NIL