### PR TITLE
Feature/import export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ go.work.sum
 # env file
 .env
 
+# Encrypted & Archive files
+*.enc
+*.zip
 # Editor/IDE
 # .idea/
 # .vscode/

--- a/internal/backup/export.go
+++ b/internal/backup/export.go
@@ -1,0 +1,72 @@
+package backup
+
+import (
+	"github.com/Cyrof/govault/internal/crypto"
+	"github.com/Cyrof/govault/internal/fileIO"
+	"github.com/Cyrof/govault/internal/logger"
+	"github.com/Cyrof/govault/internal/vault"
+	"github.com/Cyrof/govault/pkg/cli"
+)
+
+func Export(password string, v *vault.Vault, outPath string, keyOutPath string) {
+	// generate aes to encrypt vault and meta data
+	archiveAES, err := crypto.GenerateAES()
+	if err != nil {
+		cli.Error("Failed to generate AES cipher: %v\n", err)
+		logger.Logger.Errorw("Failed to generate AES cipher", "error", err)
+	}
+
+	// generate new kdf to encrypt key.enc
+	newSalt, err := crypto.GenerateSalt(32)
+	if err != nil {
+		cli.Error("Failed to generate salt")
+		logger.Logger.Errorw("Failed to generate salt", "error", err)
+	}
+	derivedKey := crypto.KDF(password, newSalt)
+
+	// read and encrypt both file
+	vaultData, metaData, err := v.FileIO.ReadAll()
+	if err != nil {
+		cli.Error("Error reading file: %v\n", err)
+		logger.Logger.Errorw("Error reading file", "error", err)
+	}
+
+	encryptVaultData, err := v.Crypto.Encrypt(vaultData, &crypto.EncryptOptions{Key: archiveAES})
+	if err != nil {
+		cli.Error("Failed to encrypt data: %v\n", err)
+		logger.Logger.Errorw("Failed to encrypt data", "error", err)
+	}
+	encryptMetaData, err := v.Crypto.Encrypt(metaData, &crypto.EncryptOptions{Key: archiveAES})
+	if err != nil {
+		cli.Error("Failed to encrypt data: %v\n", err)
+		logger.Logger.Errorw("Failed to encrypt data", "error", err)
+	}
+
+	files := map[string][]byte{
+		"vault.enc.aes": encryptVaultData,
+		"meta.json.aes": encryptMetaData,
+	}
+
+	if err := fileIO.WriteEncryptedZip(outPath, files); err != nil {
+		cli.Error("Failed to created zip: %v\n", err)
+		logger.Logger.Panicw("Failed to create zip", "error", err)
+	}
+
+	// encrypt aes key using master password and export it
+	encryptedAESKey, err := v.Crypto.Encrypt(archiveAES, &crypto.EncryptOptions{Key: derivedKey})
+	if err != nil {
+		cli.Error("Failed to encrypt data: %v\n", err)
+		logger.Logger.Errorw("Failed to encrypt data", "error", err)
+	}
+	keyFileContent := append(newSalt, encryptedAESKey...)
+
+	if err := fileIO.WriteKeyFile(keyFileContent, keyOutPath); err != nil {
+		cli.Error("Failed to export key file")
+		logger.Logger.Errorw("Failed to export key file", "error", err)
+	}
+
+	cli.Success("Vault exported successfully")
+	cli.Success("Key file exported successfully")
+	logger.Logger.Info("Vault exported successfully")
+	logger.Logger.Info("Key file exported successfully")
+}

--- a/internal/backup/import.go
+++ b/internal/backup/import.go
@@ -1,0 +1,87 @@
+package backup
+
+import (
+	"encoding/json"
+	"os"
+
+	"github.com/Cyrof/govault/internal/crypto"
+	"github.com/Cyrof/govault/internal/fileIO"
+	"github.com/Cyrof/govault/internal/logger"
+	"github.com/Cyrof/govault/internal/model"
+	"github.com/Cyrof/govault/internal/vault"
+	"github.com/Cyrof/govault/pkg/cli"
+)
+
+func Import(password string, encZip string, keyFile string, v *vault.Vault) {
+	// read key file
+	keyData, err := os.ReadFile(keyFile)
+	if err != nil {
+		cli.Error("Failed to read key file: %v", err)
+		logger.Logger.Errorw("Failed to read key file", "error", err)
+	}
+
+	if len(keyData) < 32 {
+		cli.Error("Key file is corrupted or incomplete")
+		logger.Logger.Error("Key file is corrupted or incomplete")
+	}
+
+	salt := keyData[:32]
+	cipherKey := keyData[32:]
+	derivedKey := crypto.KDF(password, salt)
+
+	archiveAES, err := v.Crypto.Decrypt(cipherKey, &crypto.DecryptOptions{Key: derivedKey})
+	if err != nil {
+		cli.Error("Failed to decrypt AES key: %v", err)
+		logger.Logger.Errorw("Failed to decrypt AES key", "error", err)
+	}
+
+	// read encrypted zip
+	files, err := fileIO.ReadEncryptedZip(encZip)
+	if err != nil {
+		cli.Error("Failed to read zip archive: %v", err)
+		logger.Logger.Errorw("Failed to read zip archive", "error", err)
+	}
+
+	vaultEnc, ok1 := files["vault.enc.aes"]
+	metaEnc, ok2 := files["meta.json.aes"]
+	if !ok1 || !ok2 {
+		cli.Error("Missing required files in archive")
+		logger.Logger.Error("Missing required files in archive")
+	}
+
+	// decrypt vault + meta
+	vaultData, err := v.Crypto.Decrypt(vaultEnc, &crypto.DecryptOptions{Key: archiveAES})
+	if err != nil {
+		cli.Error("Failed to decrypt vault data: %v", err)
+		logger.Logger.Errorw("Failed to decrypt vault data", "error", err)
+	}
+
+	metaData, err := v.Crypto.Decrypt(metaEnc, &crypto.DecryptOptions{Key: archiveAES})
+	if err != nil {
+		cli.Error("Failed to decrypt meta data: %v", err)
+		logger.Logger.Errorw("Failed to decrypt meta data", "error", err)
+	}
+
+	// write to file
+	v.FileIO.EnsureVaultDir()
+	if err := v.FileIO.WriteSecret(vaultData); err != nil {
+		cli.Error("Failed to write vault: %v", err)
+		logger.Logger.Errorw("Failed to write to vault", "error", err)
+	}
+	cli.Success("Vault restored successfully.\n")
+	logger.Logger.Info("Vault restored successfully")
+
+	var meta model.Meta
+	if err := json.Unmarshal(metaData, &meta); err != nil {
+		cli.Error("Failed to unmarshal meta: %v", err)
+		logger.Logger.Errorw("Failed to unmarshal meta", "error", err)
+	}
+	if err := v.FileIO.WriteMeta(meta); err != nil {
+		cli.Error("Failed to write meta: %v", err)
+		logger.Logger.Errorw("Failed to write meta", "error", err)
+	}
+	cli.Success("Meta data restored successfully.\n\n")
+	logger.Logger.Info("Meta data restored successfully.")
+
+	cli.Success("You may now resume using your vault with your original master password.")
+}

--- a/internal/backup/import.go
+++ b/internal/backup/import.go
@@ -63,7 +63,11 @@ func Import(password string, encZip string, keyFile string, v *vault.Vault) {
 	}
 
 	// write to file
-	v.FileIO.EnsureVaultDir()
+	if err := v.FileIO.EnsureVaultDir(); err != nil {
+		cli.Error("Failed to initialise vault directory: %v\n", err)
+		logger.Logger.Panicw("Failed to initialise vault directory", "error", err)
+	}
+
 	if err := v.FileIO.WriteSecret(vaultData); err != nil {
 		cli.Error("Failed to write vault: %v", err)
 		logger.Logger.Errorw("Failed to write to vault", "error", err)

--- a/internal/crypto/aes.go
+++ b/internal/crypto/aes.go
@@ -1,0 +1,16 @@
+package crypto
+
+import (
+	"crypto/rand"
+)
+
+func GenerateAES() ([]byte, error) {
+	key := make([]byte, 32)
+
+	_, err := rand.Read(key)
+	if err != nil {
+		return nil, err
+	}
+
+	return key, nil
+}

--- a/internal/crypto/decrypt.go
+++ b/internal/crypto/decrypt.go
@@ -6,8 +6,17 @@ import (
 	"errors"
 )
 
-func (c *Crypto) Decrypt(ciphertext []byte) ([]byte, error) {
-	block, err := aes.NewCipher(c.Key)
+type DecryptOptions struct {
+	Key []byte
+}
+
+func (c *Crypto) Decrypt(ciphertext []byte, opt *DecryptOptions) ([]byte, error) {
+	key := c.Key
+	if opt != nil && opt.Key != nil {
+		key = opt.Key
+	}
+
+	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/crypto/encrypt.go
+++ b/internal/crypto/encrypt.go
@@ -7,8 +7,17 @@ import (
 	"io"
 )
 
-func (c *Crypto) Encrypt(data []byte) ([]byte, error) {
-	block, err := aes.NewCipher(c.Key)
+type EncryptOptions struct {
+	Key []byte
+}
+
+func (c *Crypto) Encrypt(data []byte, opt *EncryptOptions) ([]byte, error) {
+	key := c.Key
+	if opt != nil && opt.Key != nil {
+		key = opt.Key
+	}
+
+	block, err := aes.NewCipher(key)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/crypto/kdf.go
+++ b/internal/crypto/kdf.go
@@ -10,6 +10,7 @@ func KDF(password string, salt []byte) []byte {
 	return argon2.IDKey([]byte(password), salt, 1, 64*1024, 4, 32)
 }
 
-func VerifyHash(inputHash []byte, storedHash []byte) bool {
-	return bytes.Equal(inputHash, storedHash)
+func VerifyHash(password string, storedSalt, storedHash []byte) ([]byte, bool) {
+	key := KDF(password, storedSalt)
+	return key, bytes.Equal(key, storedHash)
 }

--- a/internal/crypto/setup.go
+++ b/internal/crypto/setup.go
@@ -13,8 +13,8 @@ func (c *Crypto) SetupNewPassword(password string) error {
 }
 
 func (c *Crypto) SetupFromMeta(password string, storedSalt, storedHash []byte) error {
-	key := KDF(password, storedSalt)
-	if !VerifyHash(key, storedHash) {
+	key, ok := VerifyHash(password, storedSalt, storedHash)
+	if !ok {
 		return errors.New("invalid password")
 	}
 

--- a/internal/fileIO/read.go
+++ b/internal/fileIO/read.go
@@ -38,3 +38,16 @@ func (f *FileIO) ReadMeta() ([]byte, []byte, error) {
 func (f *FileIO) ReadVault() ([]byte, error) {
 	return os.ReadFile(f.VaultPath)
 }
+
+// read and return raw data of both file
+func (f *FileIO) ReadAll() ([]byte, []byte, error) {
+	vaultData, err := os.ReadFile(f.VaultPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	metaData, err := os.ReadFile(f.MetaPath)
+	if err != nil {
+		return nil, nil, err
+	}
+	return vaultData, metaData, nil
+}

--- a/internal/fileIO/read.go
+++ b/internal/fileIO/read.go
@@ -79,14 +79,15 @@ func ReadEncryptedZip(zipPath string) (map[string][]byte, error) {
 		}
 
 		var buf bytes.Buffer
-		if _, err := io.Copy(&buf, rc); err != nil {
-			rc.Close()
-			retErr = fmt.Errorf("failed to read zip entry %s: %w", f.Name, err)
+		_, copyErr := io.Copy(&buf, rc)
+		closeErr := rc.Close()
+
+		if copyErr != nil {
+			retErr = fmt.Errorf("failed to read zip entry %s: %w", f.Name, copyErr)
 			break
 		}
-
-		if err := rc.Close(); err != nil {
-			retErr = fmt.Errorf("failed to close zip entry %s: %w", f.Name, err)
+		if closeErr != nil {
+			retErr = fmt.Errorf("failed to close zip entry %s: %w", f.Name, closeErr)
 			break
 		}
 

--- a/internal/fileIO/write.go
+++ b/internal/fileIO/write.go
@@ -1,9 +1,12 @@
 package fileIO
 
 import (
+	"archive/zip"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/Cyrof/govault/internal/model"
 )
@@ -20,4 +23,70 @@ func (f *FileIO) WriteMeta(meta model.Meta) error {
 // function to write to vault file
 func (f *FileIO) WriteSecret(data []byte) error {
 	return os.WriteFile(f.VaultPath, data, 0600)
+}
+
+func WriteEncryptedZip(outPath string, files map[string][]byte) (retErr error) {
+	if outPath == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		outPath = filepath.Join(cwd, "vault_export.zip")
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outPath), os.ModePerm); err != nil {
+		return err
+	}
+
+	// prevent overwrite
+	if _, err := os.Stat(outPath); err == nil {
+		return errors.New("file already exists as " + outPath)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("unable to check file: %w", err)
+	}
+
+	outFile, err := os.Create(outPath)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := outFile.Close(); cerr != nil && retErr == nil {
+			retErr = cerr
+		}
+	}()
+
+	zipWriter := zip.NewWriter(outFile)
+	defer func() {
+		if cerr := zipWriter.Close(); cerr != nil && retErr == nil {
+			retErr = cerr
+		}
+	}()
+
+	for name, data := range files {
+		writer, err := zipWriter.Create(name)
+		if err != nil {
+			return err
+		}
+		if _, err := writer.Write(data); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func WriteKeyFile(data []byte, outPath string) error {
+	if outPath == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		outPath = filepath.Join(cwd, "key.enc")
+	}
+
+	if err := os.WriteFile(outPath, data, 0600); err != nil {
+		return fmt.Errorf("failed to write key to file: %w", err)
+	}
+
+	return nil
 }

--- a/internal/vault/persistence.go
+++ b/internal/vault/persistence.go
@@ -16,7 +16,7 @@ func (v *Vault) Save() error {
 	}
 
 	// encrypt data
-	encData, err := v.Crypto.Encrypt(data)
+	encData, err := v.Crypto.Encrypt(data, nil)
 	if err != nil {
 		return fmt.Errorf("failed to encrypt secrets: %w", err)
 	}
@@ -37,7 +37,7 @@ func (v *Vault) Load() error {
 	}
 
 	// decrypt data
-	data, err := v.Crypto.Decrypt(encData)
+	data, err := v.Crypto.Decrypt(encData, nil)
 	if err != nil {
 		return fmt.Errorf("failed to decrypt secrets: %w", err)
 	}

--- a/pkg/cobraCLI/export.go
+++ b/pkg/cobraCLI/export.go
@@ -1,0 +1,52 @@
+package cobraCLI
+
+import (
+	"github.com/Cyrof/govault/internal/backup"
+	"github.com/Cyrof/govault/internal/crypto"
+	"github.com/Cyrof/govault/internal/logger"
+	"github.com/Cyrof/govault/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+var (
+	out    string
+	keyOut string
+)
+
+var exportCmd = &cobra.Command{
+	Use:     "export",
+	Aliases: []string{"ep"},
+	Short:   "Export you encrypted vault and metadata securely",
+	Long: `The 'export' command securely exports your vault data and metadata by encrypting them into an archive file (ZIP format).
+	It also generates a seperate key file (key.enc) that contains the encrypted AES key used for securing the archive.
+	This key file is protected using your master password, ensuring only you can decrypt it later for import.`,
+	Example: `
+	govault export --out vault-backup.zip --key-out key.enc
+	govault export	# Exports to default current directory 
+	`,
+	Run: func(cmd *cobra.Command, args []string) {
+		salt, hash, err := v.FileIO.ReadMeta()
+		if err != nil {
+			cli.Error("Failed to read metadata.\nExiting...\n\n")
+			logger.Logger.Fatalw("Failed to load meta", "path", v.FileIO.MetaPath, "error", err)
+		}
+
+		password, _ := cli.PromptPassword()
+		_, ok := crypto.VerifyHash(password, salt, hash)
+		if !ok {
+			cli.Error("Incorrect master password.\nAborting export.\n\n")
+			logger.Logger.Warn("Export aborted due to incorrect password")
+			return
+		}
+
+		backup.Export(password, v, out, keyOut)
+	},
+}
+
+func init() {
+	exportCmd.Flags().StringVar(&out, "out", "", "Output path for encrypted ZIP archive")
+	exportCmd.Flags().StringVar(&keyOut, "key-out", "", "Output path for encrypted AES key file")
+
+	rootCmd.AddCommand(exportCmd)
+
+}

--- a/pkg/cobraCLI/import.go
+++ b/pkg/cobraCLI/import.go
@@ -1,0 +1,45 @@
+package cobraCLI
+
+import (
+	"github.com/Cyrof/govault/internal/backup"
+	"github.com/Cyrof/govault/internal/logger"
+	"github.com/Cyrof/govault/pkg/cli"
+	"github.com/spf13/cobra"
+)
+
+var (
+	in    string
+	keyIn string
+)
+
+var importCmd = &cobra.Command{
+	Use:     "import",
+	Aliases: []string{"im"},
+	Short:   "Import an encrypted vault archive and ites associated key file",
+	Long:    `The 'import' command securely restores your vault and metadata from an encrypted ZIP archive, by decrypting it with a password-protected key file that contains the AES key used during export, ensuring both security and usability while maintaining data integrity.`,
+	Example: `
+	govault import --in vault_export.zip --key-in key.enc
+	govault im --in vault_export2.zip --key-in key2.enc
+	`,
+	Run: func(cmd *cobra.Command, args []string) {
+		password, _ := cli.PromptPassword()
+		backup.Import(password, in, keyIn, v)
+	},
+}
+
+func init() {
+	importCmd.Flags().StringVar(&in, "in", "", "Input path for encrypted archive")
+	importCmd.Flags().StringVar(&keyIn, "key-in", "", "Input path for encrypted key file")
+
+	if err := importCmd.MarkFlagRequired("in"); err != nil {
+		cli.Error("Failed to mark flag as required\n\n")
+		logger.Logger.Panicw("Failed to mark flag as required", "flag", "in", "error", err)
+	}
+
+	if err := importCmd.MarkFlagRequired("key-in"); err != nil {
+		cli.Error("Failed to mark flag as required\n\n")
+		logger.Logger.Panicw("Failed to mark flag as required", "flag", "key-in", "error", err)
+	}
+
+	rootCmd.AddCommand(importCmd)
+}

--- a/pkg/cobraCLI/root.go
+++ b/pkg/cobraCLI/root.go
@@ -16,6 +16,7 @@ var (
 		"purge":      true,
 		"completion": true,
 		"generate":   true,
+		"import":     true,
 	}
 
 	v *vault.Vault
@@ -25,6 +26,11 @@ var (
 		Short: "A secure local password vault CLI tool",
 		Long:  cli.LoadBanner(),
 		PersistentPreRun: func(cmd *cobra.Command, args []string) {
+			// initialise dependencies
+			crypto := crypto.NewCrypto()
+			io := fileIO.NewFileIO()
+			v = vault.NewVault(io, crypto)
+
 			// skip if its just the root command
 			if cmd.Parent() == nil || skipSetupCommands[cmd.Name()] {
 				return
@@ -34,11 +40,6 @@ var (
 			if !cmd.Runnable() {
 				return
 			}
-
-			// initialise dependencies
-			crypto := crypto.NewCrypto()
-			io := fileIO.NewFileIO()
-			v = vault.NewVault(io, crypto)
 
 			// run login/setup
 			cli.Setup(v)


### PR DESCRIPTION
## Description

Describe the purpose of this pull request and the changes made.
Create `import` and `export` features for the govault cli tool. These features allow user to be able to export their current vault and import it to another device if necessary. The export features exports the `vault.enc` and `meta.json` file to `vault.enc.aes` and `meta.json.aes` respectively. Both files are placed in an archive file `vault_export.zip` and its content is encrypted using a new aes hash. This new aes hash is saved into a `key.enc` seperate from the `vault_export.zip`. The aes hash is again encrypted using a new kdf hash from the user's master password. This kdf hash is different from the one used to encrypt and decrypt the vault content as it is re-generated using a new salt. The salt is also stored in the `key.enc` file to allow the tool to use it to re-generate the kdf hash to decrypt the aes hash during import.

## Related Issue(s) and PR(s)

List any related issues or pull requests. Example: Fixes #123, Closes #456.
- Closes #50 

## Changes Made

- Added export feature 
- Added import feature 

## Additional Notes

Provide any extra information, such as testing steps, potential impact or deployment considerations.
NIL